### PR TITLE
Display test descriptions in overview

### DIFF
--- a/lua/clojure-test/ui/components/tree.lua
+++ b/lua/clojure-test/ui/components/tree.lua
@@ -36,6 +36,15 @@ local function assertion_to_line(assertion)
     table.insert(line, NuiText("Fail"))
   end
 
+  if next(assertion.context) then
+    table.insert(line, NuiText(
+      " - " .. table.concat(
+        utils.reverse_table(assertion.context),
+        " "
+      )
+    ))
+  end
+
   return line
 end
 


### PR DESCRIPTION
This PR adds a concatenation of the names of `testing` blocks. This is useful to understand where the failed assertion is located.

**Before**

<img width="1894" height="1206" alt="Screenshot 2026-01-03 at 19 46 07" src="https://github.com/user-attachments/assets/d874d3bc-81bc-492b-8250-808b49f7deb8" />


**After**

<img width="1894" height="1206" alt="Screenshot 2026-01-03 at 19 45 25" src="https://github.com/user-attachments/assets/fbfd7563-ae58-4059-9101-e9cb7f073238" />


---

Thanks so much @julienvincent for your work! I'm also using Neovim for work in Clojure using Jujutsu so I'm using multiple of your plugins daily like Hunk, Clojure-test and nvim-paredit. Much appreciated! 🙏 
